### PR TITLE
fixed typo in font name

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -330,7 +330,7 @@ a:hover { color: #000;}
 	padding: 8px 8px 8px 8px;
 	font-size: 0.8em;
 	overflow: hidden;
-	font-family: "Lucida Console", Monaco, monospaces;
+	font-family: "Lucida Console", Monaco, monospace;
 	color: #666;
 	line-height: 1.3em;
 }
@@ -480,7 +480,7 @@ a:hover { color: #000;}
 	margin: 0;
 	font-size: 1.1em;
 	color: #666;
-	font-family: "Lucida Console", Monaco, monospaces;
+	font-family: "Lucida Console", Monaco, monospace;
 	cursor: text;
 }
 


### PR DESCRIPTION
I tried to run Yarn on linux (Centos 7), which has none of the specified fonts so tries to fall back to the base family which was set to "monospaces". This doesn't exist, so I got a non monospace font, which totally borks Ace editor. It looks like it was just a typo in the css, so I dropped the pluralisation and it fixed it.