### PR TITLE
export to new window using data urls

### DIFF
--- a/app/js/classes/data.js
+++ b/app/js/classes/data.js
@@ -281,9 +281,9 @@ var data =
 
 	saveFileDialog: function(dialog, type, content)
 	{
-        var file = 'file.' + type;
+		var file = 'file.' + type;
 
-        if (app.fs)
+		if (app.fs)
 		{
 			dialog.attr("nwsaveas", file);
 			data.openFileDialog(dialog, function(e, path)
@@ -293,18 +293,18 @@ var data =
 		}
 		else
 		{
-            switch(type) {
-                case 'json':
-                    content = "data:text/json," + content;
-                    break;
-                case 'xml':
-                    content = "data:text/xml," + content;
-                    break;
-                default:
-                    content = "data:text/plain," + content;
-                    break;
-            }
-            window.open(content, "_blank");
+			switch(type) {
+				case 'json':
+					content = "data:text/json," + content;
+					break;
+				case 'xml':
+					content = "data:text/xml," + content;
+					break;
+				default:
+					content = "data:text/plain," + content;
+					break;
+			}
+			window.open(content, "_blank");
 		}
 	},
 

--- a/app/js/classes/data.js
+++ b/app/js/classes/data.js
@@ -279,11 +279,13 @@ var data =
 		dialog.trigger("click");
 	},
 
-	saveFileDialog: function(dialog, defaultValue, content)
+	saveFileDialog: function(dialog, type, content)
 	{
-		if (app.fs)
+        var file = 'file.' + type;
+
+        if (app.fs)
 		{
-			dialog.attr("nwsaveas", defaultValue);
+			dialog.attr("nwsaveas", file);
 			data.openFileDialog(dialog, function(e, path)
 			{
 				data.saveTo(path, content);
@@ -291,9 +293,18 @@ var data =
 		}
 		else
 		{
-			var w = window.open();
-			$(w.document.body).css("white-space", "pre");
-			$(w.document.body).html(content);
+            switch(type) {
+                case 'json':
+                    content = "data:text/json," + content;
+                    break;
+                case 'xml':
+                    content = "data:text/xml," + content;
+                    break;
+                default:
+                    content = "data:text/plain," + content;
+                    break;
+            }
+            window.open(content, "_blank");
 		}
 	},
 
@@ -315,7 +326,7 @@ var data =
 	trySave: function(type)
 	{
 		data.editingType(type);
-		data.saveFileDialog($('#save-file'), 'file.' + type, data.getSaveData(type));
+		data.saveFileDialog($('#save-file'), type, data.getSaveData(type));
 	},
 
 	trySaveCurrent: function()


### PR DESCRIPTION
I was running in a browser (rather than nwjs), and the save options didn't work when I added conditionals (the << was making it try to render as html tags).

I changed the save function to pass the type through and use that to decide on a data url format.

I left the twee export as plain text because I wasn't sure what else to pick, seems to work. The xml comes through as invalid now though, which I think could be fixed by adding a valid xml opening tag to the content string.