### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Yarn
+
+Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
+
+## How to send in your contributions
+
+There are many ways you can send your contributions to Yarn. You can either **report a bug**, or you can make the changes yourself and **submit a pull request**!
+
+### Reporting bugs and opening issues
+
+Please [report bugs](https://github.com/infiniteammoinc/Yarn/issues) and open issues generously. Don't be afraid that your idea is silly, or you're reporting a duplicate. We're happy to hear from you. Seriously.
+
+> ***Please Note:*** Yarn is written by volunteers. If you encounter a problem while using it, we'll do our best to help you, but the authors cannot offer any support.
+
+### Submitting a pull request
+
+* [Fork](https://github.com/infiniteammoinc/Yarn/fork) and clone the repository
+* Create a new branch: git checkout -b my-branch-name
+* Make your changes
+* Push to your fork and [submit a pull request](https://github.com/infiniteammoinc/Yarn/compare)
+* Pat your self on the back and wait for your pull request to be reviewed.
+
+If you're unfamiliar with how pull requests work, [GitHub's documentation on them](https://help.github.com/articles/using-pull-requests/) is very good.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+* Update the documentation as necessary, as well as making code changes.
+* Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+* [Write a good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+### Code and other contributions
+
+Contributions to Yarn (via pull request or otherwise) must be licensed under the MIT license.


### PR DESCRIPTION
I've added a new file, called CONTRIBUTING.md. It contains info on how to contribute to the project; importantly, it notes that any new material contributed must be under the MIT license.

Because this file is called CONTRIBUTING.md, GitHub will automatically show a link to it when creating an issue.