### PR TITLE
version 0.2.0

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -108,10 +108,10 @@ a:hover { color: #000;}
 
 .app-menu
 {
-    position: absolute;
-    top: 20px;
-    right: 20px;
-    z-index: 100;
+	position: absolute;
+	top: 20px;
+	right: 20px;
+	z-index: 100;
 }
 
 .app-menu .menu
@@ -183,9 +183,9 @@ a:hover { color: #000;}
 .app-search
 {
 	position: absolute;
-    top: 20px;
-    left: 20px;
-    z-index: 100;
+	top: 20px;
+	left: 20px;
+	z-index: 100;
 
 	background: #fff;
 	border-radius: 2px;

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -40,13 +40,13 @@ input[type='checkbox'] { width: 20px; height: 20px; margin: 0; padding: 0; line-
 a { color: #2f919a; text-decoration: none; transition: color 0.25s; }
 a:hover { color: #000;}
 
-::-webkit-scrollbar	
-{ 
-	background: -webkit-linear-gradient(top, #eee, #f4f4f4 50%, #eee); 
-	border-radius: 12px; 
+::-webkit-scrollbar
+{
+	background: -webkit-linear-gradient(top, #eee, #f4f4f4 50%, #eee);
+	border-radius: 12px;
 	border: 1px solid #e8e8e8;
-	border-top: 1px solid #ccc; 
-	border-bottom: 1px solid #ccc; 
+	border-top: 1px solid #ccc;
+	border-bottom: 1px solid #ccc;
 	cursor: pointer;
 }
 ::-webkit-scrollbar-button { display: none; }
@@ -106,20 +106,12 @@ a:hover { color: #000;}
 
 /* --- MENU --- */
 
-.app-controller
-{
-	position: absolute;
-	top: 20px;
-	left: 20px;
-	right: 20px;
-	z-index: 100;
-	float: left;
-}
-
 .app-menu
 {
-	float: right;
-	display: inline;
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    z-index: 100;
 }
 
 .app-menu .menu
@@ -135,6 +127,10 @@ a:hover { color: #000;}
 	text-transform: uppercase;
 	background: #fff;
 	cursor: pointer;
+}
+
+.app-menu .menu:first-child {
+	margin-left: 0;
 }
 
 .app-menu .title
@@ -186,8 +182,10 @@ a:hover { color: #000;}
 
 .app-search
 {
-	float: left;
-	display: inline;
+	position: absolute;
+    top: 20px;
+    left: 20px;
+    z-index: 100;
 
 	background: #fff;
 	border-radius: 2px;
@@ -557,4 +555,18 @@ a:hover { color: #000;}
 	pointer-events: none;
 	border: 1px solid #49eff1;
 	background-color: rgba(29, 94, 95, 0.2);
+}
+
+/* --- MEDIA --- */
+
+@media (max-width: 830px) {
+	.app-search {
+		position: relative;
+		float: left;
+	}
+	.app-menu {
+		position: relative;
+		float: right;
+		margin-top: 20px;
+	}
 }

--- a/app/index.html
+++ b/app/index.html
@@ -32,53 +32,51 @@
 		<!-- Entry Point / Container -->
 		<div id="app">
 
-			<div class="app-controller">
-				<!-- search form -->
-				<div class="app-search">
-					<input type="text" class="search-field"/>
-					<span class="search-title"><input type="checkbox" checked="checked"> Title</span>
-					<span class="search-body"><input type="checkbox"> Body</span>
-					<span class="search-tags"><input type="checkbox"> Tags</span>
+			<!-- search form -->
+			<div class="app-search">
+				<input type="text" class="search-field"/>
+				<span class="search-title"><input type="checkbox" checked="checked"> Title</span>
+				<span class="search-body"><input type="checkbox"> Body</span>
+				<span class="search-tags"><input type="checkbox"> Tags</span>
+			</div>
+
+			<!-- zoom controls -->
+			<!--
+			<div class="app-zoom">
+				<span data-bind="click: function() { app.zoom(4); }"></span>
+				<span data-bind="click: function() { app.zoom(3); }"></span>
+				<span data-bind="click: function() { app.zoom(2); }"></span>
+				<span data-bind="click: function() { app.zoom(1); }"></span>
+			</div>
+			-->
+
+			<!--
+			<div class="app-sort">
+				<span data-bind="click: function() { app.arrangeGrid(); }">G</span>
+				<span data-bind="click: function() { app.arrangeSpiral(); }">S</span>
+				<span data-bind="click: function() { app.sortAlphabetical(); }">A</span>
+			</div>
+			-->
+
+			<!-- navigation / menu -->
+			<div class="app-menu">
+				<div class="menu">
+					<span class="title" data-bind="click:app.newNode">+ Node</span>
 				</div>
 
-				<!-- zoom controls -->
-				<!--
-				<div class="app-zoom">
-					<span data-bind="click: function() { app.zoom(4); }"></span>
-					<span data-bind="click: function() { app.zoom(3); }"></span>
-					<span data-bind="click: function() { app.zoom(2); }"></span>
-					<span data-bind="click: function() { app.zoom(1); }"></span>
-				</div>
-				-->
-
-				<!--
-				<div class="app-sort">
-					<span data-bind="click: function() { app.arrangeGrid(); }">G</span>
-					<span data-bind="click: function() { app.arrangeSpiral(); }">S</span>
-					<span data-bind="click: function() { app.sortAlphabetical(); }">A</span>
-				</div>
-				-->
-
-				<!-- navigation / menu -->
-				<div class="app-menu">
-					<div class="menu">
-						<span class="title" data-bind="click:app.newNode">+ Node</span>
-					</div>
-
-					<div class="menu">
-						<span class="title">File</span>
-						<div class="dropdown">
-							<span class="item" data-bind="click: data.tryOpenFile">Open...</span>
-							<!--<span class="item" data-bind="click: data.tryOpenFolder">Open Folder...</span>-->
-							<span class="item" data-bind="click: data.tryAppend">Append...</span>
-							<!-- ko if:data.editingPath() != null -->
-							<span class="item" data-bind="click: data.trySaveCurrent">Save</span>
-							<!-- /ko -->
-							<span class="item" data-bind="click: function() { data.trySave(FILETYPE.JSON); }">Save As Json...</span>
-							<span class="item" data-bind="click: function() { data.trySave(FILETYPE.TWEE); }">Save As Twee...</span>
-							<span class="item" data-bind="click: function() { data.trySave(FILETYPE.XML); }">Save As Xml...</span>
-							<!--<span class="item" data-bind="click: app.quit">Close</span>-->
-						</div>
+				<div class="menu">
+					<span class="title">File</span>
+					<div class="dropdown">
+						<span class="item" data-bind="click: data.tryOpenFile">Open...</span>
+						<!--<span class="item" data-bind="click: data.tryOpenFolder">Open Folder...</span>-->
+						<span class="item" data-bind="click: data.tryAppend">Append...</span>
+						<!-- ko if:data.editingPath() != null -->
+						<span class="item" data-bind="click: data.trySaveCurrent">Save</span>
+						<!-- /ko -->
+						<span class="item" data-bind="click: function() { data.trySave(FILETYPE.JSON); }">Save As Json...</span>
+						<span class="item" data-bind="click: function() { data.trySave(FILETYPE.TWEE); }">Save As Twee...</span>
+						<span class="item" data-bind="click: function() { data.trySave(FILETYPE.XML); }">Save As Xml...</span>
+						<!--<span class="item" data-bind="click: app.quit">Close</span>-->
 					</div>
 				</div>
 			</div>

--- a/app/index.html
+++ b/app/index.html
@@ -23,18 +23,6 @@
 		<script type="text/javascript" src="js/classes/data.js"></script>
 		<script type="text/javascript" src="js/classes/utils.js"></script>
 		<script type="text/javascript" src="js/classes/node.js"></script>
-
-		<!-- start it all up! -->
-		<script type="text/javascript">
-
-			var app = new App("Yarn", "0.1.0");
-
-			$(document).ready(function()
-			{
-				app.run();
-			});
-
-		</script>
 	</head>
 	<body>
 
@@ -182,6 +170,12 @@
 		<!-- templates container (they get loaded into this) -->
 		<div class="templates">
 		</div>
+
+		<!-- start it all up! -->
+		<script type="text/javascript">
+			var app = new App("Yarn", "0.1.0");
+			app.run();
+		</script>
 
 	</bosy>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -175,5 +175,5 @@
 			app.run();
 		</script>
 
-	</bosy>
+	</body>
 </html>

--- a/app/js/classes/app.js
+++ b/app/js/classes/app.js
@@ -299,7 +299,7 @@ var App = function(name, version)
 
 		$(document).on('keyup keydown', function(e) { self.shifted = e.shiftKey; } );
 
-		$(document).mousedown(function(e){ 
+		$(document).contextmenu( function(e){ 
 			if( e.button == 2 )
 			{
 				var x = self.transformOrigin[0] * -1 / self.cachedScale,
@@ -310,7 +310,7 @@ var App = function(name, version)
 
 				self.newNodeAt(x, y); 
 			} 
-			return true; 
+			return false; 
 		}); 
 
 		$(document).on('keydown', function(e){

--- a/app/js/classes/app.js
+++ b/app/js/classes/app.js
@@ -1005,7 +1005,7 @@ var App = function(name, version)
 	{
 		for (var i in self.nodes())
 		{
-			var node = self.nodes()[i];console.log(offX, offY);
+			var node = self.nodes()[i];
 			node.moveTo(node.x() + offX, node.y() + offY);
 		}
 	}

--- a/app/js/classes/app.js
+++ b/app/js/classes/app.js
@@ -19,10 +19,16 @@ var App = function(name, version)
 	this.editingSaveHistoryTimeout = null;
 	this.dirty = false;
 	this.zoomSpeed = .005;
+	this.transformOrigin = [
+		0,
+		0
+	];
 	this.shifted = false;
 	//this.editingPath = ko.observable(null);
 
 	this.nodeSelection = [];
+
+	this.$searchField = $(".search-field");
 
 	// node-webkit
 	if (typeof(require) == "function")
@@ -63,7 +69,7 @@ var App = function(name, version)
 		}
 
 		// search field enter
-		$(".search-field").on("keydown", function (e)
+		self.$searchField.on("keydown", function (e)
 		{
 				// enter
 				if (e.keyCode == 13)
@@ -123,7 +129,7 @@ var App = function(name, version)
 				MarqueeSelection = [];
 				MarqRect = {x1:0,y1:0,x2:0,y2:0};
 
-				var scale = $(".nodes-holder").css("scale");
+				var scale = self.cachedScale;
 
 				MarqueeOffset[0] = 0;
 				MarqueeOffset[1] = 0;
@@ -163,7 +169,7 @@ var App = function(name, version)
 					{	
 						MarqueeOn = true;
 
-						var scale = $(".nodes-holder").css("scale");
+						var scale = self.cachedScale;
 
 						if(e.pageX > offset.x && e.pageY < offset.y) 
 						{
@@ -260,22 +266,35 @@ var App = function(name, version)
 		})();
 
 		// search field
-		$(".search-field").on('input', self.updateSearch);
+		self.$searchField.on('input', self.updateSearch);
 		$(".search-title input").click(self.updateSearch);
 		$(".search-body input").click(self.updateSearch);
 		$(".search-tags input").click(self.updateSearch);
 
 		// using the event helper
 		$('.nodes').mousewheel(function(event) {
-			self.cachedScale += event.deltaY * self.zoomSpeed * self.cachedScale;
+			var lastZoom = self.cachedScale,
+				scaleChange = event.deltaY * self.zoomSpeed * self.cachedScale;
 
-			$(".nodes-holder").css({ transformOrigin: ""+$(window).width()/2+"px "+$(window).height()/2+"px" });
-			if (self.cachedScale > 1)
+			if (self.cachedScale + scaleChange > 1) {
 				self.cachedScale = 1;
-			if (self.cachedScale < .25)
-				self.cachedScale = .25;
-			$(".nodes-holder").transition({ scale: self.cachedScale }, 0);
+			} else if (self.cachedScale + scaleChange < .025) {
+				self.cachedScale = .025;
+			} else {
+				self.cachedScale += scaleChange;
+			};
 
+			var mouseX = event.pageX - self.transformOrigin[0],
+				mouseY = event.pageY - self.transformOrigin[1],
+				newX = mouseX * (self.cachedScale / lastZoom),
+				newY = mouseY * (self.cachedScale / lastZoom),
+				deltaX = (mouseX - newX),
+				deltaY = (mouseY - newY);
+
+			self.transformOrigin[0] += deltaX;
+			self.transformOrigin[1] += deltaY;
+
+			self.translate();
 		});
 
 		$(document).on('keyup keydown', function(e) { self.shifted = e.shiftKey; } );
@@ -283,7 +302,13 @@ var App = function(name, version)
 		$(document).mousedown(function(e){ 
 			if( e.button == 2 )
 			{
-				self.newNodeAt(e.pageX / self.cachedScale, e.pageY / self.cachedScale); 
+				var x = self.transformOrigin[0] * -1 / self.cachedScale,
+					y = self.transformOrigin[1] * -1 / self.cachedScale;
+
+				x += event.pageX / self.cachedScale;
+				y += event.pageY / self.cachedScale;
+
+				self.newNodeAt(x, y); 
 			} 
 			return true; 
 		}); 
@@ -302,6 +327,25 @@ var App = function(name, version)
 				}
 			}
 		});
+
+		$(document).on('keydown', function(e) {
+			if (self.editing() || self.$searchField.is(':focus')) return;
+
+			var scale = self.cachedScale || 1,
+				movement = scale * 500;
+
+			if (e.keyCode === 65 || e.keyCode === 37) {  // a or left arrow
+				self.transformOrigin[0] += movement;
+			} else if (e.keyCode === 68 || e.keyCode === 39) {  // d or right arrow
+				self.transformOrigin[0] -= movement;
+			} else if (e.keyCode === 87 || e.keyCode === 38) {  // w or up arrow
+				self.transformOrigin[1] += movement;
+			} else if (e.keyCode === 83 || e.keyCode === 40) {  // w or down arrow
+				self.transformOrigin[1] -= movement;
+			}
+
+			self.translate(100);
+		} );
 		// apple command key
 		//$(window).on('keydown', function(e) { if (e.keyCode == 91 || e.keyCode == 93) { self.appleCmdKey = true; } });
 		//$(window).on('keyup', function(e) { if (e.keyCode == 91 || e.keyCode == 93) { self.appleCmdKey = false; } });
@@ -354,6 +398,9 @@ var App = function(name, version)
 	this.refreshWindowTitle = function(editingPath)
 	{
 		var gui = require('nw.gui');
+
+		if (!gui) return;
+
 		// Get the current window
 		var win = gui.Window.get();
 
@@ -587,7 +634,7 @@ var App = function(name, version)
 
 	this.updateSearch = function()
 	{
-		var search = $(".search-field").val().toLowerCase();
+		var search = self.$searchField.val().toLowerCase();
 		var title = $(".search-title input").is(':checked');
 		var body = $(".search-body input").is(':checked');
 		var tags = $(".search-tags input").is(':checked');
@@ -639,7 +686,7 @@ var App = function(name, version)
 		self.canvas.width = $(window).width();
 		self.canvas.height = $(window).height();
 
-		var scale = $(".nodes-holder").css("scale");
+		var scale = self.cachedScale;
 		var offset = $(".nodes-holder").offset();
 
 		self.context.clearRect(0, 0, $(window).width(), $(window).height());
@@ -911,28 +958,18 @@ var App = function(name, version)
 
 	}
 
-	this.zoom = function(zoomLevel)
+	this.translate = function(speed)
 	{
-		const duration = 200;
-
-		$(".nodes-holder").css({ transformOrigin: ""+$(window).width()/2+"px "+$(window).height()/2+"px" });
-
-		switch (zoomLevel)
-		{
-			case 1:
-			self.cachedScale = 0.25;
-			break;
-			case 2:
-			self.cachedScale = 0.5;
-			break;
-			case 3:
-			self.cachedScale = 0.75;
-			break;
-			case 4:
-			self.cachedScale = 1;
-			break;
-		}
-		$(".nodes-holder").transition({ scale: self.cachedScale }, duration);
+		$(".nodes-holder").transition({
+			transform: (
+				"matrix(" +
+					self.cachedScale + ",0,0," +
+					self.cachedScale + "," +
+					self.transformOrigin[0] +"," +
+					self.transformOrigin[1] +
+				")"
+			)
+		}, speed || 0);
 	}
 
 	this.arrangeGrid = function()
@@ -968,22 +1005,29 @@ var App = function(name, version)
 	{
 		for (var i in self.nodes())
 		{
-			var node = self.nodes()[i];
+			var node = self.nodes()[i];console.log(offX, offY);
 			node.moveTo(node.x() + offX, node.y() + offY);
 		}
 	}
 
 	this.searchZoom = function()
 	{
-		var search = $(".search-field").val().toLowerCase();
+		var search = self.$searchField.val().toLowerCase();
 		for (var i in self.nodes())
 		{
 			var node = self.nodes()[i];
 			if (node.title().toLowerCase() == search)
 			{
-				var centerX = $(window).width()/2;
-				var centerY = $(window).height()/2;
-				self.moveNodes(centerX - node.x() - node.tempWidth/2, centerY - node.y() - node.tempHeight/2);
+				var nodeXScaled = -( node.x() * self.cachedScale ),
+					nodeYScaled = -( node.y() * self.cachedScale ),
+					winXCenter = $(window).width() / 2,
+					winYCenter = $(window).height() / 2,
+					nodeWidthShift = node.tempWidth * self.cachedScale / 2,
+					nodeHeightShift = node.tempHeight * self.cachedScale / 2;
+
+				self.transformOrigin[0] = nodeXScaled + winXCenter - nodeWidthShift;
+				self.transformOrigin[1] = nodeYScaled + winYCenter - nodeHeightShift;
+				self.translate(100);
 				break;
 			}
 		}
@@ -991,7 +1035,7 @@ var App = function(name, version)
 
 	this.clearSearch = function()
 	{
-		$(".search-field").val("");
+		self.$searchField.val("");
 		self.updateSearch();
 	}
 }

--- a/app/js/classes/data.js
+++ b/app/js/classes/data.js
@@ -45,7 +45,7 @@ var data =
 						data.loadData(contents, type, clearNodes);
 				}
 			}
-			reader.readAsBinaryString(e.target.files[0]);
+			reader.readAsText(e.target.files[0], "UTF-8");
 		}
 		else
 		{

--- a/app/js/classes/node.js
+++ b/app/js/classes/node.js
@@ -196,8 +196,8 @@ var Node = function()
 			if (dragging)
 			{
 				var parent = $(self.element).parent();
-				var newX = (e.pageX / parent.css("scale") - offset[0]);
-				var newY = (e.pageY / parent.css("scale") - offset[1]);
+				var newX = (e.pageX / self.getScale() - offset[0]);
+				var newY = (e.pageY / self.getScale() - offset[1]);
 				var movedX = newX - self.x();
 				var movedY = newY - self.y();
 
@@ -246,8 +246,8 @@ var Node = function()
 					groupDragging = true;
 				}
 
-				offset[0] = (e.pageX / parent.css("scale") - self.x());
-				offset[1] = (e.pageY / parent.css("scale") - self.y());
+				offset[0] = (e.pageX / self.getScale() - self.x());
+				offset[1] = (e.pageY / self.getScale() - self.y());
 			}
 		});
 
@@ -331,6 +331,14 @@ var Node = function()
 					if (other != self && other.title().toLowerCase() == links[i])
 						self.linkedTo.push(other);
 			}
+		}
+	}
+
+	this.getScale = function() {
+		if (app && typeof app.cachedScale === 'number') {
+			return app.cachedScale;
+		} else {
+			return 1;
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Yarn",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"main": "app/index.html",
 	"window": {
 		"toolbar": false,


### PR DESCRIPTION
I should have created a pull request for each feature, but a bit short on time, sorry. You can always revert parts you don't want.

Changelog:
* Merged "remove rightclick context menu" from firestack's fork
* Added navigation: WASD and arrow keys move the canvas in all directions and zoom now works as on Google Maps (zooming in/out according to the cursor position). I personally can't use Yarn without this feature
* Fix encoding. Replaced `readAsBinaryString` with `readAsText`, because JSON files with "non-standard" letters (öäüß) don't work at the moment. I checked only the "Open..." menu with a JSON file and haven't checked XML and Twee. **I assume that [this change](https://github.com/InfiniteAmmoInc/Yarn/commit/ac847bd89c4467ceb8259c92df466bcc598beb46) is safe, but can be tested better.**
* Main menu doesn't use a shared container anymore. The gap between the search pane and the buttons drives me crazy, be cause it looks like zoom and select should work there, but they don't
* Fixed the `</bosy>` typo (was it a typo?)

The version is bumped to 0.2.0 because of the `readAsText` change.