### PR TITLE
allow contextmenu in node edit

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -171,7 +171,7 @@
 
 		<!-- start it all up! -->
 		<script type="text/javascript">
-			var app = new App("Yarn", "0.1.0");
+			var app = new App("Yarn", "0.2.1");
 			app.run();
 		</script>
 

--- a/app/js/classes/app.js
+++ b/app/js/classes/app.js
@@ -299,8 +299,13 @@ var App = function(name, version)
 
 		$(document).on('keyup keydown', function(e) { self.shifted = e.shiftKey; } );
 
-		$(document).contextmenu( function(e){ 
-			if( e.button == 2 )
+		$(document).contextmenu( function(e){
+			var isAllowedEl = (
+					$(e.target).hasClass('nodes') ||
+					$(e.target).parents('.nodes').length
+				);
+
+			if( e.button == 2 && isAllowedEl )
 			{
 				var x = self.transformOrigin[0] * -1 / self.cachedScale,
 					y = self.transformOrigin[1] * -1 / self.cachedScale;
@@ -310,7 +315,8 @@ var App = function(name, version)
 
 				self.newNodeAt(x, y); 
 			} 
-			return false; 
+
+			return !isAllowedEl; 
 		}); 
 
 		$(document).on('keydown', function(e){

--- a/app/js/classes/app.js
+++ b/app/js/classes/app.js
@@ -964,6 +964,27 @@ var App = function(name, version)
 
 	}
 
+	this.zoom = function(zoomLevel)
+	{
+		switch (zoomLevel)
+		{
+			case 1:
+				self.cachedScale = 0.25;
+				break;
+			case 2:
+				self.cachedScale = 0.5;
+				break;
+			case 3:
+				self.cachedScale = 0.75;
+				break;
+			case 4:
+				self.cachedScale = 1;
+				break;
+		}
+
+		self.translate(200);
+	}
+
 	this.translate = function(speed)
 	{
 		$(".nodes-holder").transition({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Yarn",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"main": "app/index.html",
 	"window": {
 		"toolbar": false,


### PR DESCRIPTION
This is an improvement for https://github.com/firestack/Yarn/commit/6be29fe2a87b279298a7e51ca17dd0cc89f5029c

Instead of disabling the context menu completely, it's now disabled only for the main canvas, but still allowed for other elements, e.g. edit dialogs.

---

I also returned the `zoom` method--it now works with the new zooming implementation. The method is not used anywhere (well, only in a commented out code block), so I just pushed it directly to master.