### PR TITLE
A very minor fix to enable Linux for NW.js v0.16.1

### DIFF
--- a/app/js/classes/app.js
+++ b/app/js/classes/app.js
@@ -58,7 +58,7 @@ var App = function(name, version)
 		self.context = self.canvas.getContext('2d');
 		self.newNode().title("Start");
 
-		if (osName != "Windows" && self.gui != undefined)
+		if (osName != "Windows" && osName != "Linux" && self.gui != undefined)
 		{
 			var win = self.gui.Window.get();
 			var nativeMenuBar = new self.gui.Menu({ type: "menubar" });


### PR DESCRIPTION
Without this fix, Linux functionality is totally broken on Ubuntu 16.04 and NW.js v0.16.1 - you cannot click off of a node once the node is created.

This simply sets the menu bar functionality for Linux to be the same as Windows, as per the NW.js documentation: http://docs.nwjs.io/en/latest/For%20Users/Advanced/Customize%20Menubar/
