### PR TITLE
Tweak keydown code to allow less jumpy movement

### DIFF
--- a/app/js/classes/app.js
+++ b/app/js/classes/app.js
@@ -350,6 +350,10 @@ var App = function(name, version)
 			var scale = self.cachedScale || 1,
 				movement = scale * 500;
 
+			if(e.shiftKey) {
+				movement = scale * 100;
+			}
+
 			if (e.keyCode === 65 || e.keyCode === 37) {  // a or left arrow
 				self.transformOrigin[0] += movement;
 			} else if (e.keyCode === 68 || e.keyCode === 39) {  // d or right arrow


### PR DESCRIPTION
Moving around the canvas feels very twitchy due to the size of the jump on each arrow keydown. This adds a check for holding shift (so as not to change existing user experience) and drops the movement down by a 5th, allowing more precision alignment of elements within the window.