### PR TITLE
Fix marquee (selection box)

### DIFF
--- a/app/js/classes/app.js
+++ b/app/js/classes/app.js
@@ -176,7 +176,7 @@ var App = function(name, version) {
               MarqRect.x1 = offset.x;
               MarqRect.y1 = e.pageY;
               MarqRect.x2 = e.pageX;
-              MarqRect.y2 = e.pageY;
+              MarqRect.y2 = offset.y;
             } else if (e.pageX > offset.x && e.pageY > offset.y) {
               MarqRect.x1 = offset.x;
               MarqRect.y1 = offset.y;


### PR DESCRIPTION
When dragging from the bottom left corner to the right up corner, the marquee wouldn't display and select correctly (it was displayed as an horizontal line instead of a box)

![2018-07-04_22h49_46](https://user-images.githubusercontent.com/340056/42293787-f0bf8ca4-7fdc-11e8-9fb5-cba2513a7ce2.png)

