### PR TITLE
Fix for issue #78 loading yarn.txt with \r\n lines

### DIFF
--- a/app/js/classes/data.js
+++ b/app/js/classes/data.js
@@ -135,7 +135,7 @@ var data = {
       }
       for (i = 0; i < content.length; i++) objects.push(content[i]);
     } else if (type == FILETYPE.YARNTEXT) {
-      var lines = content.split("\n");
+      var lines = content.split(/\r?\n/);
       var obj = null;
       var index = 0;
       var readingBody = false;


### PR DESCRIPTION
When loading a yarn.txt file, Yarn was expecting lines to end only with
\n and didn't handle properly lines ending with \r\n.

Yarn saves files using only \n, even on Windows, but if the user modify
the file manually, some editors on Windows will convert \n to \r\n, so
it must be taken into account.